### PR TITLE
Switch to libopenmpt

### DIFF
--- a/Hurrican/CMakeLists.txt
+++ b/Hurrican/CMakeLists.txt
@@ -468,16 +468,16 @@ if(UNIX)
     add_definitions(-DUSE_STORAGE_PATH="${CMAKE_INSTALL_PREFIX}/share/hurrican/")
 endif()
 
-OPTION(MODPLUG "Use MODPLUG natively" OFF)
-IF(MODPLUG)
-    ADD_DEFINITIONS(-DUSE_MODPLUG)
-    target_link_libraries(${PROJECT_NAME} modplug)
-ENDIF(MODPLUG)
-
 include_directories(${CMAKE_SOURCE_DIR}/src)
 include_directories(${CMAKE_SOURCE_DIR}/src/SDLPort)
 include_directories(${CMAKE_SOURCE_DIR}/3rdparty/glm)
-add_executable(hurrican ${HURRICAN_SOURCES})
+add_executable(${PROJECT_NAME} ${HURRICAN_SOURCES})
+
+OPTION(OPENMPT "Use OPENMPT for ImpulseTracker music file decoding" OFF)
+IF(OPENMPT)
+    ADD_DEFINITIONS(-DUSE_OPENMPT)
+    target_link_libraries(${PROJECT_NAME} openmpt)
+ENDIF(OPENMPT)
 
 set(SDL2_BUILDING_LIBRARY TRUE)
 find_package(SDL2)

--- a/Hurrican/src/DX8Sound.cpp
+++ b/Hurrican/src/DX8Sound.cpp
@@ -207,12 +207,12 @@ void SoundManagerClass::UpdateSongs() {
                 songs[i].pause_when_fade_ends = false;
             }
         } else if (SongIsPlaying(i)) {
-#ifndef USE_MODPLUG
+#ifndef USE_OPENMPT
             // DKS - Added this, because when SDL_mixer loops a music file, at least in some versions or
             //      configurations, it resets the song's volume to a default value. So, we must
             //      set the volume continuously.
             SetSongVolume(i, songs[i].vol);
-#endif  // !USE_MODPLUG
+#endif  // !USE_OPENMPT
         }
     }
 }

--- a/Hurrican/src/SDLPort/SDL_fmod.hpp
+++ b/Hurrican/src/SDLPort/SDL_fmod.hpp
@@ -27,14 +27,14 @@
 
 #include "SDL_mixer.h"
 #include "SDL_port.hpp"
-#if defined(USE_MODPLUG)
-#include "libmodplug/modplug.h"
+#if defined(USE_OPENMPT)
+#include "libopenmpt/libopenmpt.h"
 #endif
 #include "Logdatei.hpp"
 
 #define SOUND_SAMPLE Mix_Chunk
-#if defined(USE_MODPLUG)
-#define MUSIC_MODULE ModPlugFile
+#if defined(USE_OPENMPT)
+#define MUSIC_MODULE openmpt_module
 #else
 #define MUSIC_MODULE Mix_Music
 #endif
@@ -93,7 +93,7 @@ signed char SOUND_StopSound(int channel);
 signed char SOUND_SetPaused(int channel, signed char paused);
 signed char SOUND_GetPaused(int channel);
 
-#if defined(USE_MODPLUG)
+#if defined(USE_OPENMPT)
 void hookmusic(void *ptr, uint8_t *buffer, int size);
 #else
 void hookmusicFinished();

--- a/README.md
+++ b/README.md
@@ -79,5 +79,5 @@ OpenGL Options
 * -DEGL=ON                : Enable EGL support, available only with GL2 or GL3
 
 Sound
-* -DMODPLUG=ON            : Use the modplug code for music (useful when building with older SDL_mixer, which uses the lower quality mikmod engine)
+* -DOPENMPT=ON            : Use the libopenmpt code for music (SDL2_mixer uses libmodplug while SDL_mixer uses the lower quality mikmod engine)
 


### PR DESCRIPTION
libmodplug is already used internally by SDL2_mixer and it's long unmaintained, so allow using the more modern libopenmpt as an alternative