### PR TITLE
Add gamepad pause/menu function  (Fixes #7)

### DIFF
--- a/Hurrican/src/DX8Input.cpp
+++ b/Hurrican/src/DX8Input.cpp
@@ -79,6 +79,10 @@ DirectInputClass::~DirectInputClass() = default;
 // Keyboard und Maus initialisieren und Joystick, falls vorhanden
 // --------------------------------------------------------------------------------------
 bool DirectInputClass::Init() {
+#if SDL_VERSION_ATLEAST(2,0,0)
+    SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER);
+#endif
+
 #if SDL_VERSION_ATLEAST(2, 0, 0)
     TastaturPuffer = SDL_GetKeyboardState(&NumberOfKeys);
 #else

--- a/Hurrican/src/DX8Joystick.cpp
+++ b/Hurrican/src/DX8Joystick.cpp
@@ -169,5 +169,5 @@ bool DirectJoystickClass::ButtonDeletePressed() {
 }
 
 bool DirectJoystickClass::ButtonStartPressed() {
-    return JoystickButtons[8];  // FIXME
+    return JoystickButtons[7];  // FIXME
 }

--- a/Hurrican/src/DX8Joystick.cpp
+++ b/Hurrican/src/DX8Joystick.cpp
@@ -167,3 +167,7 @@ bool DirectJoystickClass::ButtonEscapePressed() {
 bool DirectJoystickClass::ButtonDeletePressed() {
     return JoystickButtons[4];  // Default is button 4
 }
+
+bool DirectJoystickClass::ButtonStartPressed() {
+    return JoystickButtons[8];  // FIXME
+}

--- a/Hurrican/src/DX8Joystick.cpp
+++ b/Hurrican/src/DX8Joystick.cpp
@@ -32,8 +32,11 @@ DirectJoystickClass::DirectJoystickClass() {
     CanForceFeedback = false;
     NumButtons = 0;
 
-    // hardcoded button values
+    // hardcoded default button values
     startButton = 7;
+    enterButton = 0;
+    backButton = 1;
+    deleteButton = 4;
 
     for (int i = 0; i < MAX_JOYSTICKBUTTONS; i++)
         JoystickButtons[i] = false;
@@ -95,20 +98,39 @@ bool DirectJoystickClass::Init(int joy) {
         JoystickName[sizeof(JoystickName) - 1] = '\0';                            // and null-terminate
     }
 
+    Protokoll << "Joystick " << joy << ": Acquire successful!\nButtons: " << NumButtons
+        << " \nName: " << JoystickName << std::endl;
+
 #if SDL_VERSION_ATLEAST(2,0,0)
     if (SDL_IsGameController(joy)) {
+        Protokoll << "It's a Game Controller, mapping standard buttons..." << std::endl;
+
         SDL_GameController* controller = SDL_GameControllerOpen(joy);
-        SDL_GameControllerButtonBind bind = SDL_GameControllerGetBindForButton(controller, SDL_CONTROLLER_BUTTON_START);
+        SDL_GameControllerButtonBind bind;
+        
+        bind = SDL_GameControllerGetBindForButton(controller, SDL_CONTROLLER_BUTTON_START);
         if (bind.bindType != SDL_CONTROLLER_BINDTYPE_NONE) {
             startButton = bind.value.button;
-            Protokoll << "Button Start mapped to " << startButton << std::endl;
+            Protokoll << "Start function mapped to button START (" << startButton << ")" << std::endl;
+        }
+        bind = SDL_GameControllerGetBindForButton(controller, SDL_CONTROLLER_BUTTON_A);
+        if (bind.bindType != SDL_CONTROLLER_BINDTYPE_NONE) {
+            enterButton = bind.value.button;
+            Protokoll << "Enter function mapped to button A (" << startButton << ")" << std::endl;
+        }
+        bind = SDL_GameControllerGetBindForButton(controller, SDL_CONTROLLER_BUTTON_B);
+        if (bind.bindType != SDL_CONTROLLER_BINDTYPE_NONE) {
+            backButton = bind.value.button;
+            Protokoll << "Back function mapped to button B (" << startButton << ")" << std::endl;
+        }
+        bind = SDL_GameControllerGetBindForButton(controller, SDL_CONTROLLER_BUTTON_LEFTSHOULDER);
+        if (bind.bindType != SDL_CONTROLLER_BINDTYPE_NONE) {
+            deleteButton = bind.value.button;
+            Protokoll << "Delete function mapped to button LB (" << startButton << ")" << std::endl;
         }
         SDL_GameControllerClose(controller);
     }
 #endif
-
-    Protokoll << "Joystick " << joy << ": Acquire successful!\nButtons: " << NumButtons << " Name: " << JoystickName
-              << std::endl;
 
     return true;
 }
@@ -176,15 +198,15 @@ bool DirectJoystickClass::Update() {
 
 // DKS-Added these three for better joystick support, esp in menus
 bool DirectJoystickClass::ButtonEnterPressed() {
-    return JoystickButtons[0];  // Default is button 0
+    return JoystickButtons[enterButton];
 }
 
 bool DirectJoystickClass::ButtonEscapePressed() {
-    return JoystickButtons[1];  // Default is button 1
+    return JoystickButtons[backButton];
 }
 
 bool DirectJoystickClass::ButtonDeletePressed() {
-    return JoystickButtons[4];  // Default is button 4
+    return JoystickButtons[deleteButton];
 }
 
 bool DirectJoystickClass::ButtonStartPressed() {

--- a/Hurrican/src/DX8Joystick.cpp
+++ b/Hurrican/src/DX8Joystick.cpp
@@ -14,6 +14,10 @@
 #include "Gameplay.hpp"
 #include "Logdatei.hpp"
 
+#if SDL_VERSION_ATLEAST(2,0,0)
+#  include <SDL_gamecontroller.h>
+#endif
+
 // --------------------------------------------------------------------------------------
 // Konstruktor
 // --------------------------------------------------------------------------------------
@@ -27,6 +31,9 @@ DirectJoystickClass::DirectJoystickClass() {
     JoystickPOV = -1;
     CanForceFeedback = false;
     NumButtons = 0;
+
+    // hardcoded button values
+    startButton = 7;
 
     for (int i = 0; i < MAX_JOYSTICKBUTTONS; i++)
         JoystickButtons[i] = false;
@@ -87,6 +94,18 @@ bool DirectJoystickClass::Init(int joy) {
         strcpy_s(JoystickName, sizeof(JoystickName) - 1, SDL_JoystickName(SDLJOYINDEX));  // Truncate to fit
         JoystickName[sizeof(JoystickName) - 1] = '\0';                            // and null-terminate
     }
+
+#if SDL_VERSION_ATLEAST(2,0,0)
+    if (SDL_IsGameController(joy)) {
+        SDL_GameController* controller = SDL_GameControllerOpen(joy);
+        SDL_GameControllerButtonBind bind = SDL_GameControllerGetBindForButton(controller, SDL_CONTROLLER_BUTTON_START);
+        if (bind.bindType != SDL_CONTROLLER_BINDTYPE_NONE) {
+            startButton = bind.value.button;
+            Protokoll << "Button Start mapped to " << startButton << std::endl;
+        }
+        SDL_GameControllerClose(controller);
+    }
+#endif
 
     Protokoll << "Joystick " << joy << ": Acquire successful!\nButtons: " << NumButtons << " Name: " << JoystickName
               << std::endl;
@@ -169,5 +188,5 @@ bool DirectJoystickClass::ButtonDeletePressed() {
 }
 
 bool DirectJoystickClass::ButtonStartPressed() {
-    return JoystickButtons[7];  // FIXME
+    return JoystickButtons[startButton];
 }

--- a/Hurrican/src/DX8Joystick.hpp
+++ b/Hurrican/src/DX8Joystick.hpp
@@ -67,5 +67,8 @@ class DirectJoystickClass {
 
     // Returns true if button(s) serving as Delete key are pressed (For menus, esp. button mapping menu)
     bool ButtonDeletePressed();
+
+    // Returns true if button(s) serving as Start key are pressed (For game)
+    bool ButtonStartPressed();
 };
 #endif

--- a/Hurrican/src/DX8Joystick.hpp
+++ b/Hurrican/src/DX8Joystick.hpp
@@ -49,6 +49,9 @@ class DirectJoystickClass {
     int NumButtons;                             // How many buttons joystick supports
 
     int startButton;
+    int enterButton;
+    int backButton;
+    int deleteButton;
 
     DirectJoystickClass();
     ~DirectJoystickClass();

--- a/Hurrican/src/DX8Joystick.hpp
+++ b/Hurrican/src/DX8Joystick.hpp
@@ -48,6 +48,8 @@ class DirectJoystickClass {
     char JoystickName[70];                      // Joystick Produktname
     int NumButtons;                             // How many buttons joystick supports
 
+    int startButton;
+
     DirectJoystickClass();
     ~DirectJoystickClass();
 

--- a/Hurrican/src/Gameplay.cpp
+++ b/Hurrican/src/Gameplay.cpp
@@ -438,7 +438,7 @@ void GameLoop() {
         ShowGameOver();
 
     // Gameloop verlassen ?
-    if ((KeyDown(DIK_ESCAPE) || DirectInput.Joysticks[Player[0].JoystickIndex].ButtonEscapePressed())
+    if ((KeyDown(DIK_ESCAPE) || DirectInput.Joysticks[Player[0].JoystickIndex].ButtonStartPressed())
             && Player[0].GameOverTimer == 0.0f)
         LeaveGameLoop();
 

--- a/Hurrican/src/Gameplay.cpp
+++ b/Hurrican/src/Gameplay.cpp
@@ -438,7 +438,8 @@ void GameLoop() {
         ShowGameOver();
 
     // Gameloop verlassen ?
-    if (KeyDown(DIK_ESCAPE) && Player[0].GameOverTimer == 0.0f)
+    if ((KeyDown(DIK_ESCAPE) || DirectInput.Joysticks[Player[0].JoystickIndex].ButtonEscapePressed())
+            && Player[0].GameOverTimer == 0.0f)
         LeaveGameLoop();
 
 #if defined(GCW)


### PR DESCRIPTION
Allow returning to the game menu using a gamepad or joystick button.
Also implement runtime game controller button mapping (only available with SDL2).